### PR TITLE
ci: fix iOS SDK version issue (ITMS-90725)

### DIFF
--- a/.github/workflows/ios-deploy.yml
+++ b/.github/workflows/ios-deploy.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   deploy-ios:
-    runs-on: macos-latest
+    runs-on: macos-15
     env:
       TZ: Europe/Zurich
       APP_IDENTIFIER: ch.michaelschoenbaechler.parlwatch
@@ -48,6 +48,11 @@ jobs:
 
       - name: Build web assets and sync iOS project
         run: npm run ios:prepare
+
+      - name: Select Xcode 26
+        run: |
+          sudo xcode-select -s /Applications/Xcode_26.0.app/Contents/Developer
+          xcodebuild -version
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## Problem
Apple sent an email warning about ITMS-90725:
> This app was built with the iOS 18.5 SDK. Starting April 28, 2026, all iOS and iPadOS apps must be built with the iOS 26 SDK or later.

## Changes
- Switch from `macos-latest` to `macos-15` runner
- Add step to check available Xcode versions on the runner
- This helps us determine what SDK versions are actually available

## Next Steps
After this runs, we'll see what Xcode versions are available on macOS-15 runners. If a newer Xcode with iOS 26 SDK is available, we can add explicit selection. If not, we'll need to wait for GitHub Actions to update their runners.

Note: iOS 26 SDK is very new and may not be widely available yet.