### PR TITLE
fix(deps): resolve dependabot security alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## <small>2026.3.11 (2026-03-11)</small>
+
+* chore: update to Angular 21 ([5d2cd52](https://github.com/michaelschoenbaechler/parlwatch/commit/5d2cd52))
+* ci: use Xcode 26 on macOS 15 runner for iOS deploy ([be9b375](https://github.com/michaelschoenbaechler/parlwatch/commit/be9b375))
+
+
+
 ## <small>2026.3.10 (2026-03-10)</small>
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parlwatch",
-  "version": "2026.3.10",
+  "version": "2026.3.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parlwatch",
-      "version": "2026.3.10",
+      "version": "2026.3.11",
       "dependencies": {
         "@angular/common": "^21.2.2",
         "@angular/core": "^21.2.2",
@@ -15184,9 +15184,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "version": "4.12.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
+      "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parlwatch",
-  "version": "2026.3.10",
+  "version": "2026.3.11",
   "author": "Michael Schönbächler",
   "homepage": "https://github.com/michaelschoenbaechler",
   "description": "Easy access for everyone to parliamentary data",


### PR DESCRIPTION
Bumps hono from <4.12.7 to 4.12.7 to fix prototype pollution vulnerability (GHSA-v8w9-8mx6-g223).

Resolves Dependabot alert #123.

Version bumped to 2026.3.11.