### PR TITLE
fix(business): set selectedBusinessId when loading business from API

### DIFF
--- a/src/app/business/store/business/business.store.ts
+++ b/src/app/business/store/business/business.store.ts
@@ -116,7 +116,8 @@ export const BusinessStore = signalStore(
               next: (business) =>
                 patchState(
                   store,
-                  createSuccessBusinessRequestState([business])
+                  createSuccessBusinessRequestState([business]),
+                  { selectedBusinessId: id }
                 ),
               error: () => patchState(store, createErrorBusinessRequestState())
             })


### PR DESCRIPTION
## Problem

When navigating to a business detail from a council member's voting record, the page always renders empty.

## Root Cause

In `BusinessStore._selectAndLoadBusiness`, when a business isn't already cached in state, it's fetched from the API via `businessService.getBusiness(id)`. However, `selectedBusinessId` was never set after the fetch — only when the business was already cached (inside the `filter()` operator).

Since navigating from a voting record almost always hits the uncached path, `selectedBusinessId` stayed `null`, and `createBusinessDetailVm` couldn't find the business to display.

## Fix

Set `selectedBusinessId` in the `tapResponse` success handler alongside the business data.