### PR TITLE
fix(deps): resolve dependabot security alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## <small>2026.3.20 (2026-03-20)</small>
+
+* fix(deps): resolve dependabot security alerts ([0f39217](https://github.com/michaelschoenbaechler/parlwatch/commit/0f39217))
+
 ## <small>2026.3.19 (2026-03-19)</small>
 
 ## <small>2026.3.14 (2026-03-14)</small>

--- a/ios/App/Gemfile.lock
+++ b/ios/App/Gemfile.lock
@@ -169,7 +169,7 @@ GEM
     httpclient (2.9.0)
       mutex_m
     jmespath (1.6.2)
-    json (2.18.1)
+    json (2.19.2)
     jwt (2.10.2)
       base64
     logger (1.7.0)
@@ -294,7 +294,7 @@ CHECKSUMS
   http-cookie (1.0.8) sha256=b14fe0445cf24bf9ae098633e9b8d42e4c07c3c1f700672b09fbfe32ffd41aa6
   httpclient (2.9.0) sha256=4b645958e494b2f86c2f8a2f304c959baa273a310e77a2931ddb986d83e498c8
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
-  json (2.18.1) sha256=fe112755501b8d0466b5ada6cf50c8c3f41e897fa128ac5d263ec09eedc9f986
+  json (2.19.2) sha256=e7e1bd318b2c37c4ceee2444841c86539bc462e81f40d134cf97826cb14e83cf
   jwt (2.10.2) sha256=31e1ee46f7359883d5e622446969fe9c118c3da87a0b1dca765ce269c3a0c4f4
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mini_magick (4.13.2) sha256=71d6258e0e8a3d04a9a0a09784d5d857b403a198a51dd4f882510435eb95ddd9

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "parlwatch",
-  "version": "2026.3.19",
+  "version": "2026.3.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "parlwatch",
-      "version": "2026.3.19",
+      "version": "2026.3.20",
       "dependencies": {
         "@angular/common": "^21.2.4",
         "@angular/core": "^21.2.4",
@@ -13886,9 +13886,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parlwatch",
-  "version": "2026.3.19",
+  "version": "2026.3.20",
   "author": "Michael Schönbächler",
   "homepage": "https://github.com/michaelschoenbaechler",
   "description": "Easy access for everyone to parliamentary data",


### PR DESCRIPTION
This PR fixes the following Dependabot security alert:

- **json** (CVE-2026-33210): Ruby JSON has a format string injection vulnerability
  - Updated from 2.18.1 to 2.19.2 in ios/App/Gemfile.lock

Also includes version bump to 2026.3.20.